### PR TITLE
fix(dependencies): Add Flask-SocketIO 5.3.6 to requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ click==8.1.7
 colorama==0.4.6
 distro==1.8.0
 Flask==3.0.0
+Flask-SocketIO==5.3.6
 h11==0.14.0
 httpcore==1.0.1
 httpx==0.25.1


### PR DESCRIPTION
This should stop the accessibility workflow from hanging.

Changes `requirements.txt`