### PR TITLE
Removed 'Provide OpenAI API Key' from the Welcome menu

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,10 +21,6 @@
                             <i class="{% if "ide" in setup_progress %}fa-solid fa-check-circle text-purple-400{% else %}
                             fa-regular fa-circle{% endif %} mr-2"></i>Configure IDE Executable
                         </p>
-                        <p class="text-lg {% if "api" in setup_progress %}line-through text-purple-600{% endif %}">
-                            <i class="{% if "api" in setup_progress %}fa-solid fa-check-circle text-purple-400{% else %}
-                            fa-regular fa-circle{% endif %} mr-2"></i>Provide OpenAI API Key
-                        </p>
                         <p class="text-lg {% if "username" in setup_progress %}line-through text-purple-600{% endif %}">
                             <i class="{% if "username" in setup_progress %}fa-solid fa-check-circle text-purple-400{% else %}
                             fa-regular fa-circle{% endif %} mr-2"></i>Set a Username to Collaborate With Other Users


### PR DESCRIPTION
Managed to remove 'Provide OpenAI Key' from the Welcome menu. Tested thoroughly and no errors occurred.

Feel free. :)