### PR TITLE
fix: issue # 24 - dealt with no error handle for connection timeout 

### DIFF
--- a/app/remotellama.py
+++ b/app/remotellama.py
@@ -7,7 +7,10 @@ class LlamaInterface:
     headers = {"Content-Type": "application/json"}
     def query(question):
         data = {"prompt": question}
-        response = requests.post(LlamaInterface.url + 'llama', headers=LlamaInterface.headers, json=data)
+        try:
+            response = requests.post(LlamaInterface.url + 'llama', headers=LlamaInterface.headers, json=data)
+        except requests.exceptions.ConnectTimeout:
+            return "Timeout Error has occurred"
         response_data = response.json()
         # Check if the response is a dictionary before trying to access it
         if isinstance(response_data, dict):


### PR DESCRIPTION
Fixed there being no indication on the UI that there was a time out error on the llama call. Also ignore a previous pull request for this as its from a main branch accidentally and has many out of date changes to deal with. 