### PR TITLE
Fixes #50 corrected reset button action

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -217,7 +217,7 @@
             event.preventDefault();
 
             if (confirm("Are you sure you want to reset the settings? This cannot be undone.")) {
-                document.getElementById('resetSettings')
+                document.getElementById('resetSettings').submit();
             }
         }
     </script>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -214,6 +214,8 @@
             document.getElementById("updateForm").submit();
         };
         document.getElementById('reset-settings').onclick = function () {
+            event.preventDefault();
+
             if (confirm("Are you sure you want to reset the settings? This cannot be undone.")) {
                 document.getElementById('resetSettings')
             }


### PR DESCRIPTION
Reset button was resetting the settings even when user clicked _Cancel_.  Updated code prevents the submission code from occurring by default and will only execute if the user selects _Okay_.


